### PR TITLE
Added locale importing

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,9 @@ online example: http://react-component.github.io/pagination/examples/
 
 ```js
 var Pagination = require('rc-pagination');
+var usLocale = require('rc-pagination/lib/locale/en_US');
 var React = require('react');
-React.render(<Pagination />, container);
+React.render(<Pagination locale=usLocale/>, container);
 ```
 
 ## API


### PR DESCRIPTION
Probably it is better to add an example for imporint locale, or even better to change locale property type to string like 'en_US', then import it inside accordingly, so that use only has to set locale property as a string, since locale is supposed to be standard string
Or locale property could be written as 'trans' , more apropreately, so that we could remove all locale directory, let the user specify their label translation via 'trans' object
I'm a little busy at the moment, this is the lease I can do for now.